### PR TITLE
client_cookie: Add extended cookie directive parsing

### DIFF
--- a/client_cookie/lib/src/client_cookie_base.dart
+++ b/client_cookie/lib/src/client_cookie_base.dart
@@ -361,7 +361,8 @@ Map<String, ClientCookie> parseSetCookie(String? setCookieLine,
     return cookieMap;
   }
 
-  for (String itemStr in setCookieLine.split(',')) {
+  final cookieStrings = setCookieLine.split(RegExp(r',(?=[A-Za-z0-9_-]+\s*=)'));
+  for (String itemStr in cookieStrings) {
     final cookie = ClientCookie.fromSetCookie(itemStr,
         enableExtendedDirectiveParsing: enableExtendedDirectiveParsing);
     cookieMap[cookie.name] = cookie;

--- a/client_cookie/lib/src/client_cookie_base.dart
+++ b/client_cookie/lib/src/client_cookie_base.dart
@@ -297,7 +297,7 @@ class CookieStore {
 
     for (String rem in removes) cookieMap.remove(rem);
 
-    return rets.join(', ');
+    return rets.join('; ');
   }
 
   /// Parses and adds all 'set-cookies' from [http.Response] to the Cookie store

--- a/client_cookie/lib/src/client_cookie_base.dart
+++ b/client_cookie/lib/src/client_cookie_base.dart
@@ -361,7 +361,8 @@ Map<String, ClientCookie> parseSetCookie(String? setCookieLine,
     return cookieMap;
   }
 
-  final cookieStrings = setCookieLine.split(RegExp(r',(?=[A-Za-z0-9_-]+\s*=)'));
+  final cookieStrings =
+      setCookieLine.split(RegExp(r',(?=[A-Za-z0-9._-]+\s*=)'));
   for (String itemStr in cookieStrings) {
     final cookie = ClientCookie.fromSetCookie(itemStr,
         enableExtendedDirectiveParsing: enableExtendedDirectiveParsing);


### PR DESCRIPTION
Because most browsers can correct deviations from standards, many websites are a dumpster fire of nonstandard behavior.

One example are the [cookie directives](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie), that control the behavior of such. Some websites completely ignore the case of them and you might find a directive named `secure` instead of  `Secure` for example.

This PR addresses this, by providing a fallback method, that tries to find them case insensitively. It can also be disabled.
